### PR TITLE
Add conditional execution for analyze job on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
       security-events: write


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow to conditionally run the analyze job only for pull request events.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R15): Added a condition to the `analyze` job to run only if the event is a pull request.