### PR TITLE
Add conditional execution for build job based on event type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04-arm
     needs: analyze
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Implement conditional execution for the build job to run only on push or pull request events.