### PR TITLE
Remove dependency on analyze job in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,6 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04-arm
-    needs: analyze
     if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change removes the dependency on the `analyze` job for the `build` job.

Changes in `jobs:`:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L46): Removed the `needs: analyze` dependency from the `build` job.